### PR TITLE
Wasm release action uses MacOS build agent

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   build_test:
     name: Build
-    runs-on: "macos-latest"
+    runs-on: macos-latest
     defaults:
       run:
         working-directory: ./wasm

--- a/.github/workflows/release-wasm.yml
+++ b/.github/workflows/release-wasm.yml
@@ -13,7 +13,7 @@ jobs:
     name: Publish Npm
     environment:
       name: npmjs.com
-    runs-on: windows-latest
+    runs-on: macos-latest
     defaults:
       run:
         working-directory: ./wasm
@@ -23,6 +23,10 @@ jobs:
       - uses: jetli/wasm-pack-action@v0.3.0
         with:
           version: 'latest'
+      - run: |
+          rustup toolchain uninstall stable
+          rustup toolchain install stable
+          rustup toolchain install stable --target wasm32-unknown-unknown
       - name: Generate Package Version
         run: |
           $json = Invoke-WebRequest 'https://api.github.com/repos/trinsic-id/okapi/releases/latest' | ConvertFrom-Json

--- a/wasm/Generate-Proto.ps1
+++ b/wasm/Generate-Proto.ps1
@@ -1,10 +1,10 @@
 # Generate protobuf files for JS and TS
 param($OutDir = './packages/okapi-proto/src/proto')
 
-$PROTOC_GEN_TS_PATH = "./node_modules/.bin/protoc-gen-ts"
-$GRPC_TOOLS_NODE_PROTOC="./node_modules/.bin/grpc_tools_node_protoc"
-$OUTPUT_DIR=$OutDir
-$PROTO_DIR= Resolve-Path "../proto"
+$PROTOC_GEN_TS_PATH = Resolve-Path "./node_modules/.bin/protoc-gen-ts"
+$GRPC_TOOLS_NODE_PROTOC = Resolve-Path "./node_modules/.bin/grpc_tools_node_protoc"
+$OUTPUT_DIR = $OutDir
+$PROTO_DIR = Resolve-Path "../proto"
 
 foreach ($Item in Get-ChildItem -Path $PROTO_DIR -Include *.proto -Recurse) {
     $File = $Item.FullName


### PR DESCRIPTION
Fixed an issue that prevented wasm from building correctly, due to incorrect paths of protoc plugin for TS
